### PR TITLE
Switch to `process::Command` API instead of `duct`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,6 @@ name = "bevy_local_commands"
 version = "0.2.1"
 dependencies = [
  "bevy",
- "futures-lite 1.13.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,6 @@ name = "bevy_local_commands"
 version = "0.1.4"
 dependencies = [
  "bevy",
- "duct",
  "futures-lite 1.13.0",
 ]
 
@@ -1396,18 +1395,6 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
-
-[[package]]
-name = "duct"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ae3fc31835f74c2a7ceda3aeede378b0ae2e74c8f1c36559fcc9ae2a4e7d3e"
-dependencies = [
- "libc",
- "once_cell",
- "os_pipe",
- "shared_child",
-]
 
 [[package]]
 name = "encase"
@@ -2535,16 +2522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_pipe"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,16 +2857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shared_child"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,4 @@ repository = "https://github.com/edouardpoitras/bevy_local_commands"
 
 [dependencies]
 bevy = "0.11"
-duct = "0.13"
 futures-lite = "1.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,3 @@ repository = "https://github.com/edouardpoitras/bevy_local_commands"
 
 [dependencies]
 bevy = "0.12"
-futures-lite = "1.13"

--- a/examples/kill_linux.rs
+++ b/examples/kill_linux.rs
@@ -23,24 +23,24 @@ fn startup(mut shell_commands: EventWriter<RunProcess>) {
     ));
 }
 
-fn kill(active_processes: Res<ActiveProcessMap>, mut kill_shell_command: EventWriter<KillProcess>) {
+fn kill(active_processes: Res<ActiveProcessMap>, mut kill_process_event: EventWriter<KillProcess>) {
     for &pid in active_processes.0.keys() {
         info!("Killing {pid}");
-        kill_shell_command.send(KillProcess(pid));
+        kill_process_event.send(KillProcess(pid));
     }
 }
 
 fn update(
-    mut shell_command_output: EventReader<ProcessOutputEvent>,
-    mut shell_command_completed: EventReader<ProcessCompleted>,
+    mut process_output_event: EventReader<ProcessOutputEvent>,
+    mut process_completed_event: EventReader<ProcessCompleted>,
 ) {
-    for command_output in shell_command_output.read() {
+    for command_output in process_output_event.read() {
         for line in command_output.output.iter() {
             info!("Output Line ({}): {line}", command_output.pid);
         }
     }
-    if !shell_command_completed.is_empty() {
-        let completed = shell_command_completed.read().last().unwrap();
+    if !process_completed_event.is_empty() {
+        let completed = process_completed_event.read().last().unwrap();
         info!(
             "Command completed (PID - {}, Success - {}): {}",
             completed.pid, completed.success, completed.command

--- a/examples/kill_linux.rs
+++ b/examples/kill_linux.rs
@@ -1,0 +1,52 @@
+use std::time::Duration;
+
+use bevy::{prelude::*, time::common_conditions::on_timer};
+use bevy_local_commands::{
+    ActiveProcessMap, BevyLocalCommandsPlugin, KillShellCommand, RunShellCommand,
+    ShellCommandCompleted, ShellCommandOutput,
+};
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, BevyLocalCommandsPlugin))
+        .add_systems(Startup, startup)
+        .add_systems(Update, update)
+        // Kill the command after 6s
+        .add_systems(Update, kill.run_if(on_timer(Duration::from_secs(6))))
+        .run();
+}
+
+fn startup(mut shell_commands: EventWriter<RunShellCommand>) {
+    shell_commands.send(RunShellCommand::new(
+        "bash",
+        vec!["-c", "echo Sleeping for 10s && sleep 10 && echo Done"],
+    ));
+}
+
+fn kill(
+    active_processes: Res<ActiveProcessMap>,
+    mut kill_shell_command: EventWriter<KillShellCommand>,
+) {
+    for &pid in active_processes.0.keys() {
+        info!("Killing {pid}");
+        kill_shell_command.send(KillShellCommand(pid));
+    }
+}
+
+fn update(
+    mut shell_command_output: EventReader<ShellCommandOutput>,
+    mut shell_command_completed: EventReader<ShellCommandCompleted>,
+) {
+    for command_output in shell_command_output.read() {
+        for line in command_output.output.iter() {
+            info!("Output Line ({}): {line}", command_output.pid);
+        }
+    }
+    if !shell_command_completed.is_empty() {
+        let completed = shell_command_completed.read().last().unwrap();
+        info!(
+            "Command completed (PID - {}, Success - {}): {}",
+            completed.pid, completed.success, completed.command
+        );
+    }
+}

--- a/examples/kill_linux.rs
+++ b/examples/kill_linux.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use bevy::{prelude::*, time::common_conditions::on_timer};
 use bevy_local_commands::{
-    ActiveProcessMap, BevyLocalCommandsPlugin, KillShellCommand, RunShellCommand,
-    ShellCommandCompleted, ShellCommandOutput,
+    ActiveProcessMap, BevyLocalCommandsPlugin, KillProcess, ProcessCompleted, ProcessOutputEvent,
+    RunProcess,
 };
 
 fn main() {
@@ -16,26 +16,23 @@ fn main() {
         .run();
 }
 
-fn startup(mut shell_commands: EventWriter<RunShellCommand>) {
-    shell_commands.send(RunShellCommand::new(
+fn startup(mut shell_commands: EventWriter<RunProcess>) {
+    shell_commands.send(RunProcess::new(
         "bash",
         vec!["-c", "echo Sleeping for 10s && sleep 10 && echo Done"],
     ));
 }
 
-fn kill(
-    active_processes: Res<ActiveProcessMap>,
-    mut kill_shell_command: EventWriter<KillShellCommand>,
-) {
+fn kill(active_processes: Res<ActiveProcessMap>, mut kill_shell_command: EventWriter<KillProcess>) {
     for &pid in active_processes.0.keys() {
         info!("Killing {pid}");
-        kill_shell_command.send(KillShellCommand(pid));
+        kill_shell_command.send(KillProcess(pid));
     }
 }
 
 fn update(
-    mut shell_command_output: EventReader<ShellCommandOutput>,
-    mut shell_command_completed: EventReader<ShellCommandCompleted>,
+    mut shell_command_output: EventReader<ProcessOutputEvent>,
+    mut shell_command_completed: EventReader<ProcessCompleted>,
 ) {
     for command_output in shell_command_output.read() {
         for line in command_output.output.iter() {

--- a/examples/simple_linux.rs
+++ b/examples/simple_linux.rs
@@ -19,16 +19,16 @@ fn startup(mut shell_commands: EventWriter<RunProcess>) {
 }
 
 fn update(
-    mut shell_command_output: EventReader<ProcessOutputEvent>,
-    mut shell_command_completed: EventReader<ProcessCompleted>,
+    mut process_output_event: EventReader<ProcessOutputEvent>,
+    mut process_completed_event: EventReader<ProcessCompleted>,
 ) {
-    for command_output in shell_command_output.read() {
+    for command_output in process_output_event.read() {
         for line in command_output.output.iter() {
             info!("Output Line ({}): {line}", command_output.pid);
         }
     }
-    if !shell_command_completed.is_empty() {
-        let completed = shell_command_completed.read().last().unwrap();
+    if !process_completed_event.is_empty() {
+        let completed = process_completed_event.read().last().unwrap();
         info!(
             "Command completed (PID - {}, Success - {}): {}",
             completed.pid, completed.success, completed.command

--- a/examples/simple_linux.rs
+++ b/examples/simple_linux.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_local_commands::{
-    BevyLocalCommandsPlugin, RunShellCommand, ShellCommandCompleted, ShellCommandOutput,
+    BevyLocalCommandsPlugin, ProcessCompleted, ProcessOutputEvent, RunProcess,
 };
 
 fn main() {
@@ -11,16 +11,16 @@ fn main() {
         .run();
 }
 
-fn startup(mut shell_commands: EventWriter<RunShellCommand>) {
-    shell_commands.send(RunShellCommand::new(
+fn startup(mut shell_commands: EventWriter<RunProcess>) {
+    shell_commands.send(RunProcess::new(
         "bash",
         vec!["-c", "echo Sleeping for 1s && sleep 1 && echo Done"],
     ));
 }
 
 fn update(
-    mut shell_command_output: EventReader<ShellCommandOutput>,
-    mut shell_command_completed: EventReader<ShellCommandCompleted>,
+    mut shell_command_output: EventReader<ProcessOutputEvent>,
+    mut shell_command_completed: EventReader<ProcessCompleted>,
 ) {
     for command_output in shell_command_output.read() {
         for line in command_output.output.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ impl Plugin for BevyLocalCommandsPlugin {
             .add_event::<ProcessOutputEvent>()
             .add_event::<KillProcess>()
             .add_event::<ProcessCompleted>()
+            .add_event::<ProcessError>()
             .init_resource::<ActiveProcessMap>()
             .add_systems(
                 Update,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub struct ShellCommandCompleted {
 struct ProcessOutputBuffer(Arc<Mutex<Vec<String>>>);
 
 #[derive(Debug)]
-struct ActiveProcess {
+pub struct ActiveProcess {
     command: Command,
     process: Child,
     task: Task<()>,
@@ -67,7 +67,7 @@ struct ActiveProcess {
 }
 
 #[derive(Default, Resource)]
-struct ActiveProcessMap(HashMap<Pid, ActiveProcess>);
+pub struct ActiveProcessMap(pub HashMap<Pid, ActiveProcess>);
 
 pub struct BevyLocalCommandsPlugin;
 
@@ -83,8 +83,8 @@ impl Plugin for BevyLocalCommandsPlugin {
                 Update,
                 (
                     handle_new_process,
-                    handle_shell_command_output,
                     handle_kill_process,
+                    handle_shell_command_output,
                     handle_completed_shell_commands,
                 )
                     .chain(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ fn spawn_process(mut command: Command) -> ActiveProcess {
 
     let output_buffer = ProcessOutputBuffer::default();
 
-    let output_buffer_moved = output_buffer.clone();
+    let moved_buffer = output_buffer.clone();
     let thread_pool = IoTaskPool::get();
 
     // Read stdout and write it to the output buffer
@@ -203,8 +203,10 @@ fn spawn_process(mut command: Command) -> ActiveProcess {
                 break;
             }
 
-            if let Ok(mut output_buffer) = output_buffer_moved.0.lock() {
-                output_buffer.push(line.clone());
+            if let Ok(mut buffer) = moved_buffer.0.lock() {
+                // The line includes the terminating new line, but we already have all lines separated
+                buffer.push(line.trim_end_matches('\n').to_string());
+                line.clear();
             }
         }
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,8 @@ impl Plugin for BevyLocalCommandsPlugin {
                     handle_shell_command_output,
                     handle_kill_process,
                     handle_completed_shell_commands,
-                ),
+                )
+                    .chain(),
             );
     }
 }
@@ -120,8 +121,9 @@ fn handle_shell_command_output(
 ) {
     for (&pid, active_process) in active_process_map.0.iter_mut() {
         if let Ok(mut output_buffer) = active_process.output_buffer.0.lock() {
-            // Empty the output buffer and send it as event
-            let output: Vec<_> = output_buffer.drain(..).collect();
+            // Send the buffered output in the event while clearing the output buffer
+            let mut output = Vec::<String>::new();
+            std::mem::swap(&mut *output_buffer, &mut output);
 
             if !output.is_empty() {
                 shell_command_output.send(ShellCommandOutput {


### PR DESCRIPTION
Closes #4, allows us to tackle #2.

This PR explores using `process::Command` instead of the `duct` library.

This allows us to remove a dependency while gaining more control about command execution.
In particular, it allow us to read the process output while still being able to kill the process, solving #4.

Note that the completed event doesn't always trigger immediately after killing the process, especially when coupled with the `sleep` command.
If using a command like `echo Sleeping for 10s && sleep 10 && echo Done`, the `sleep` is executed in a separate thread and not killed along with the process.
So the command will not send the "Done" output anymore, but still wait the remaining 10 seconds... not sure if we can fix that.

To enable this, the following changes were made:

- Remove `duct` and `futures-lite`, as they are not needed anymore.
- Store the `Command` and `Child` (running process) for each command.
- Only wrap the output buffer in an arc mutex and not the whole command info. This improves code ergonomics and probably also performance.
- Use a `HashMap` instead of `Vec` to store the running processes. This makes the lookup of a specific PID easier.
- Add new example to demonstrate killing a process. Note that the process still "lingers" because `sleep` is being run in a separate process.