### PR TITLE
Sending process input

### DIFF
--- a/examples/linux_input.rs
+++ b/examples/linux_input.rs
@@ -1,0 +1,46 @@
+use bevy::prelude::*;
+use bevy_local_commands::{
+    BevyLocalCommandsPlugin, LocalCommand, Process, ProcessCompleted, ProcessOutput,
+};
+
+fn main() {
+    App::new()
+        .add_plugins((MinimalPlugins, BevyLocalCommandsPlugin))
+        .add_systems(Startup, startup)
+        .add_systems(Update, update)
+        .run();
+}
+
+fn startup(mut commands: Commands) {
+    let cmd = {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "echo 'Enter Name: ' && read NAME && echo Hello $NAME"]);
+        cmd
+    };
+    let id = commands.spawn(LocalCommand::new(cmd)).id();
+    println!("Spawned the command as entity {id:?}");
+}
+
+fn update(
+    mut process_output_event: EventReader<ProcessOutput>,
+    mut process_completed_event: EventReader<ProcessCompleted>,
+    mut active_processes: Query<&mut Process>,
+) {
+    for process_output in process_output_event.read() {
+        for line in process_output.output.iter() {
+            println!("Output Line ({:?}): {line}", process_output.entity);
+            if line.ends_with(": ") {
+                let mut process = active_processes.get_mut(process_output.entity).unwrap();
+                process.println("Bevy").expect("Failed to write to process");
+            }
+        }
+    }
+    if let Some(process_completed) = process_completed_event.read().last() {
+        println!(
+            "Command {:?} completed (Success - {})",
+            process_completed.entity, process_completed.success
+        );
+        // Quit the app
+        std::process::exit(0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,20 @@ impl Process {
     }
 
     /// Attempt to write the given string, terminated by a new line, into the input of this process.
+    ///
+    /// # Example
+    ///
+    /// Here's how you can write "Hello world!" to a process that has just been started:
+    ///
+    /// ```
+    /// # use bevy::prelude::*;
+    /// # use bevy_local_commands::Process;
+    /// fn provide_input(mut query: Query<&mut Process, Added<Process>>) {
+    ///     for mut process in query.iter_mut() {
+    ///         process.println("Hello world!").unwrap();
+    ///     }
+    /// }
+    /// ```
     pub fn println(&mut self, input: &str) -> Result<(), io::Error> {
         self.write_all(input.as_bytes())?;
         self.write_all(b"\n")?;


### PR DESCRIPTION
# Objective

Closes #2.

For my use-cases (managing chess engines), I need to be able to write to the stdin of a process.

# Solution

When spawning the process, the `stdin` is piped to the process and wrapped in a buffered reader.
We then provide functions like `process.println` to easily provide input to the process.

I originally intended to make the API event-based, but similar to the process killing it turned out to be easier to just query for a mutable process and call functions on it directly.
This way, we also avoid the potential frame delay of events.

I couldn't think of a simple, generally available CLI tool to demonstrate this feature with in an example.
However, I have verified that it works in my own project and added an example in a doc test.