### PR TITLE
Remove unused ProcessStarted event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,6 @@ use std::sync::Mutex;
 pub type Pid = u32;
 
 #[derive(Debug, Event)]
-pub struct ProcessStarted {
-    pub command: String,
-    pub pid: Pid,
-}
-
-#[derive(Debug, Event)]
 pub struct ProcessOutput {
     pub entity: Entity,
     pub output: Vec<String>,
@@ -78,8 +72,7 @@ pub struct BevyLocalCommandsPlugin;
 
 impl Plugin for BevyLocalCommandsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_event::<ProcessStarted>()
-            .add_event::<ProcessOutput>()
+        app.add_event::<ProcessOutput>()
             .add_event::<ProcessCompleted>()
             .add_event::<ProcessError>()
             .add_systems(


### PR DESCRIPTION
Since #11, the ProcessStarted event has not been emitted anymore.
Instead, the user can now add the `Added<Process>` filter to their query.

Dead code detection didn't catch this, because the event is public.

Note that this is a breaking change and requires us to bump the minor version number.
Perhaps we can release it together with other features though so we don't have too many releases :D