### PR TITLE
Pass `ExitStatus`  instead of success `bool` in `ProcessCompleted`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ fn send_command_input(
 ```rust
 fn get_completed(mut process_completed_event: EventReader<ProcessCompleted>) {
     for completed in process_completed_event.read() {
-        info!("Command completed (Entity - {}, Success - {})", completed.entity, completed.success);
+        info!(
+            "Command completed (Entity - {}, Success - {})",
+            completed.entity,
+            completed.exit_status.success()
+        );
     }
 }
 ```

--- a/examples/kill.rs
+++ b/examples/kill.rs
@@ -56,7 +56,8 @@ fn update(
     if let Some(completed) = process_completed_event.read().last() {
         println!(
             "Command {:?} completed (Success - {})",
-            completed.entity, completed.success
+            completed.entity,
+            completed.exit_status.success()
         );
         // Quit the app
         std::process::exit(0);

--- a/examples/linux_input.rs
+++ b/examples/linux_input.rs
@@ -38,7 +38,8 @@ fn update(
     if let Some(process_completed) = process_completed_event.read().last() {
         println!(
             "Command {:?} completed (Success - {})",
-            process_completed.entity, process_completed.success
+            process_completed.entity,
+            process_completed.exit_status.success()
         );
         // Quit the app
         std::process::exit(0);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -40,7 +40,8 @@ fn update(
     if let Some(process_completed) = process_completed_event.read().last() {
         println!(
             "Command {:?} completed (Success - {})",
-            process_completed.entity, process_completed.success
+            process_completed.entity,
+            process_completed.exit_status.success()
         );
         // Quit the app
         std::process::exit(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::io::BufWriter;
 use std::process::Child;
 use std::process::ChildStdin;
 use std::process::Command;
+use std::process::ExitStatus;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -35,7 +36,7 @@ pub struct ProcessError {
 #[derive(Debug, Event)]
 pub struct ProcessCompleted {
     pub entity: Entity,
-    pub success: bool,
+    pub exit_status: ExitStatus,
 }
 
 /// The lines written to the standard output by a given process.
@@ -242,7 +243,7 @@ fn handle_completed_process(
 
             process_completed_event.send(ProcessCompleted {
                 entity,
-                success: exit_status.success(),
+                exit_status,
             });
 
             // The process is finished, despawn the entity


### PR DESCRIPTION
# Objective

Closes #18.

Give the user access to the whole exit status of the process.

# Solution

Replace `sucess: bool` with `exit_status: ExitStatus` and adjust the examples to the new API.