### PR TITLE
Added retry capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_local_commands"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bevy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_local_commands"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Simple local shell commands for the Bevy game engine"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -83,26 +83,21 @@ fn get_completed(mut process_completed_event: EventReader<ProcessCompleted>) {
 }
 ```
 
-**Customize process behavior:**
+**Retry and cleanup behavior:**
+
 ```rust
-fn cleanup_on_completion(mut commands: Commands) {
+fn retries_and_cleanup_on_completion(mut commands: Commands) {
     commands.spawn((
-        LocalCommand::new("bash").args(["-c", "sleep 1 && echo slept"]),
-        // Also, Cleanup::RemoveComponent to remove Process and Cleanup components upon completion.
+        LocalCommand::new("bash").args(["-c", "sleep 1 && invalid-command --that=fails"]),
+        // Attempt the command 3 times before giving up
+        // NOTE: The Retry component will be removed from the entity when no retries are left
+        Retry::Attempts(3)
+        // Cleanup::DespawnEntity will despawn the entity upon process completion.
+        // Cleanup::RemoveComponents will remove this crate's components upon process completion.
         Cleanup::DespawnEntity
     ));
 }
-
-fn retry_command(mut commands: Commands) {
-    commands.spawn((
-        LocalCommand::new("bash").args(["-c", "command --that=fails"]),
-        // Attempt the command 3 times before giving up.
-        Retry::Attempts(3)
-    ));
-}
 ```
-
-NOTE: Cleanup and Retry components are not currently compatible - adding both results in undefined behavior.
 
 ## Todo
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fn get_completed(mut process_completed_event: EventReader<ProcessCompleted>) {
 }
 ```
 
-**Customize commands behaviour:**
+**Customize process behavior:**
 ```rust
 fn cleanup_on_completion(mut commands: Commands) {
     commands.spawn((
@@ -92,7 +92,17 @@ fn cleanup_on_completion(mut commands: Commands) {
         Cleanup::DespawnEntity
     ));
 }
+
+fn retry_command(mut commands: Commands) {
+    commands.spawn((
+        LocalCommand::new("bash").args(["-c", "command --that=fails"]),
+        // Attempt the command 3 times before giving up.
+        Retry::Attempts(3)
+    ));
+}
 ```
+
+NOTE: Cleanup and Retry components are not currently compatible - adding both results in undefined behavior.
 
 ## Todo
 

--- a/examples/retries.rs
+++ b/examples/retries.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
-use bevy_local_commands::{BevyLocalCommandsPlugin, LocalCommand, ProcessCompleted, Retry};
+use bevy_local_commands::{
+    BevyLocalCommandsPlugin, LocalCommand, ProcessCompleted, Retry, RetryEvent,
+};
 
 fn main() {
     App::new()
@@ -26,20 +28,23 @@ fn startup(mut commands: Commands) {
 
 fn update(
     mut process_completed_event: EventReader<ProcessCompleted>,
-    query: Query<(&LocalCommand, &Retry)>,
+    query: Query<&LocalCommand, With<Retry>>,
+    mut retry_events: EventReader<RetryEvent>,
 ) {
     if let Some(process_completed) = process_completed_event.read().last() {
-        let (local_command, retry) = query.get(process_completed.entity).unwrap();
-        println!(
-            "Command {:?} {:?} completed (Success - {})",
-            local_command.get_program(),
-            local_command.get_args(),
-            process_completed.exit_status.success()
-        );
-        println!("Retries remaining: {:?}", retry);
-        if let Retry::Attempts(0) = retry {
-            println!("No retries left, exiting");
+        if let Ok(local_command) = query.get(process_completed.entity) {
+            println!(
+                "Command {:?} {:?} completed (Success - {})",
+                local_command.get_program(),
+                local_command.get_args(),
+                process_completed.exit_status.success()
+            );
+        } else {
+            println!("Retry component removed from entity, exiting");
             std::process::exit(0);
         }
+    }
+    for retry_event in retry_events.read() {
+        println!("Retry event triggered: {:?}", retry_event);
     }
 }

--- a/examples/retries.rs
+++ b/examples/retries.rs
@@ -1,0 +1,45 @@
+use bevy::prelude::*;
+use bevy_local_commands::{BevyLocalCommandsPlugin, LocalCommand, ProcessCompleted, Retry};
+
+fn main() {
+    App::new()
+        .add_plugins((MinimalPlugins, BevyLocalCommandsPlugin))
+        .add_systems(Startup, startup)
+        .add_systems(Update, update)
+        .run();
+}
+
+fn startup(mut commands: Commands) {
+    // Choose the command based on the OS
+    #[cfg(not(windows))]
+    let cmd =
+        LocalCommand::new("sh").args(["-c", "echo Sleeping for 1s && sleep 1 && THIS SHOULD FAIL"]);
+    #[cfg(windows)]
+    let cmd = LocalCommand::new("cmd").args([
+        "/C",
+        "echo Sleeping for 1s && timeout 1 && THIS SHOULD FAIL",
+    ]);
+
+    let id = commands.spawn((cmd, Retry::Attempts(3))).id();
+    println!("Spawned the command as entity {id:?} with 3 retries");
+}
+
+fn update(
+    mut process_completed_event: EventReader<ProcessCompleted>,
+    query: Query<(&LocalCommand, &Retry)>,
+) {
+    if let Some(process_completed) = process_completed_event.read().last() {
+        let (local_command, retry) = query.get(process_completed.entity).unwrap();
+        println!(
+            "Command {:?} {:?} completed (Success - {})",
+            local_command.get_program(),
+            local_command.get_args(),
+            process_completed.exit_status.success()
+        );
+        println!("Retries remaining: {:?}", retry);
+        if let Retry::Attempts(0) = retry {
+            println!("No retries left, exiting");
+            std::process::exit(0);
+        }
+    }
+}

--- a/examples/retries_and_remove.rs
+++ b/examples/retries_and_remove.rs
@@ -1,0 +1,45 @@
+use bevy::prelude::*;
+use bevy_local_commands::{
+    BevyLocalCommandsPlugin, Cleanup, LocalCommand, ProcessCompleted, Retry,
+};
+
+fn main() {
+    App::new()
+        .add_plugins((MinimalPlugins, BevyLocalCommandsPlugin))
+        .add_systems(Startup, startup)
+        .add_systems(Update, update)
+        .run();
+}
+
+fn startup(mut commands: Commands) {
+    // Choose the command based on the OS
+    #[cfg(not(windows))]
+    let cmd = LocalCommand::new("sh").args(["-c", "echo Sleeping for 1s && sleep 1 && INVALID "]);
+    #[cfg(windows)]
+    let cmd = LocalCommand::new("cmd").args(["/C", "echo Sleeping for 1s && timeout 1 && INVALID"]);
+
+    let id = commands
+        .spawn((cmd, Retry::Attempts(3), Cleanup::DespawnEntity))
+        .id();
+    println!("Spawned the command as temporary entity {id:?} with 3 retries");
+}
+
+fn update(
+    mut process_completed_event: EventReader<ProcessCompleted>,
+    query: Query<(&LocalCommand, &Retry)>,
+) {
+    if let Some(process_completed) = process_completed_event.read().last() {
+        if let Ok((local_command, retry)) = query.get(process_completed.entity) {
+            println!(
+                "Command {:?} {:?} completed (Success - {})",
+                local_command.get_program(),
+                local_command.get_args(),
+                process_completed.exit_status.success()
+            );
+            println!("Retries remaining: {:?}", retry);
+        } else {
+            println!("Can't find entity anymore, exiting");
+            std::process::exit(0);
+        }
+    }
+}

--- a/examples/retries_and_remove.rs
+++ b/examples/retries_and_remove.rs
@@ -26,7 +26,7 @@ fn startup(mut commands: Commands) {
 
 fn update(
     mut process_completed_event: EventReader<ProcessCompleted>,
-    query: Query<(&LocalCommand, &Retry)>,
+    query: Query<(&LocalCommand, &Retry)>, // We could also listen for RetryEvent to get retry status
 ) {
     if let Some(process_completed) = process_completed_event.read().last() {
         if let Ok((local_command, retry)) = query.get(process_completed.entity) {

--- a/src/addons/cleanup.rs
+++ b/src/addons/cleanup.rs
@@ -1,24 +1,28 @@
 use bevy::prelude::*;
 
-use crate::{LocalCommand, Process, ProcessCompleted};
+use crate::{LocalCommand, Process, ProcessCompleted, Retry};
 
 #[derive(Debug, Component)]
 pub enum Cleanup {
-    None,
     DespawnEntity,
-    RemoveComponent,
+    RemoveComponents,
 }
 
 /// Clean up any completed processes according to the Cleanup component.
 ///
-/// Processes without the Cleanup component are ignored, same as Cleanup::None.
+/// Processes without the Cleanup component are ignored.
+/// Takes into account the Retry component (will not perform cleanup until component is removed).
 pub(crate) fn cleanup_completed_process(
     mut commands: Commands,
-    query: Query<&Cleanup>,
+    query: Query<(&Cleanup, Option<&Retry>)>,
     mut process_completed_events: EventReader<ProcessCompleted>,
 ) {
     for process_completed_event in process_completed_events.read() {
-        if let Ok(cleanup) = query.get(process_completed_event.entity) {
+        if let Ok((cleanup, option_retry)) = query.get(process_completed_event.entity) {
+            // Don't cleanup a failed process if the Retry component is still attached to entity.
+            if !process_completed_event.exit_status.success() && option_retry.is_some() {
+                continue;
+            }
             match cleanup {
                 Cleanup::DespawnEntity => {
                     if let Some(mut entity_commands) =
@@ -27,14 +31,13 @@ pub(crate) fn cleanup_completed_process(
                         entity_commands.despawn();
                     }
                 },
-                Cleanup::RemoveComponent => {
+                Cleanup::RemoveComponents => {
                     if let Some(mut entity_commands) =
                         commands.get_entity(process_completed_event.entity)
                     {
                         entity_commands.remove::<(Process, Cleanup, LocalCommand)>();
                     }
                 },
-                Cleanup::None => {},
             }
         }
     }

--- a/src/addons/mod.rs
+++ b/src/addons/mod.rs
@@ -1,1 +1,2 @@
 pub mod cleanup;
+pub mod retry;

--- a/src/addons/retry.rs
+++ b/src/addons/retry.rs
@@ -1,0 +1,66 @@
+use bevy::prelude::*;
+
+use crate::{LocalCommand, Process, ProcessCompleted};
+
+#[derive(Debug, Component)]
+pub enum Retry {
+    None,
+    Attempts(usize),
+}
+
+/// Retry failed processes according to the Retry component.
+///
+/// Processes without the Retry component are ignored, same as Retry::None.
+pub(crate) fn retry_failed_process(
+    mut commands: Commands,
+    query: Query<(&LocalCommand, &Retry)>,
+    mut process_completed_events: EventReader<ProcessCompleted>,
+) {
+    for process_completed_event in process_completed_events.read() {
+        if process_completed_event.exit_status.success() {
+            continue;
+        }
+        if let Ok((current_local_command, retry)) = query.get(process_completed_event.entity) {
+            match retry {
+                Retry::Attempts(retries) => {
+                    if *retries < 1 {
+                        continue;
+                    }
+                    if let Some(mut entity_commands) =
+                        commands.get_entity(process_completed_event.entity)
+                    {
+                        // Remove both the Process and LocalCommand
+                        entity_commands.remove::<(Process, LocalCommand)>();
+
+                        // Create new LocalCommand
+                        let mut new_local_command =
+                            LocalCommand::new(current_local_command.get_program());
+
+                        // Match current working directory
+                        new_local_command.command.current_dir(
+                            current_local_command
+                                .get_current_dir()
+                                .unwrap_or(std::path::Path::new(".")),
+                        );
+
+                        // Match arguments
+                        new_local_command
+                            .command
+                            .args(current_local_command.get_args());
+
+                        // Match environment variables
+                        for (key, option_value) in current_local_command.get_envs() {
+                            if let Some(value) = option_value {
+                                new_local_command.command.env(key, value);
+                            }
+                        }
+
+                        // Re-add the LocalCommand to trigger Added<LocalCommand> event for Process creation
+                        entity_commands.insert((new_local_command, Retry::Attempts(retries - 1)));
+                    }
+                },
+                Retry::None => {},
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod process;
 mod systems;
 
 pub use addons::cleanup::Cleanup;
+pub use addons::retry::Retry;
 pub use local_command::LocalCommand;
 pub use process::Process;
 
@@ -75,6 +76,7 @@ impl Plugin for BevyLocalCommandsPlugin {
                     systems::handle_process_output,
                     systems::handle_completed_process,
                     addons::cleanup::cleanup_completed_process,
+                    addons::retry::retry_failed_process,
                 )
                     .chain(),
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod process;
 mod systems;
 
 pub use addons::cleanup::Cleanup;
-pub use addons::retry::Retry;
+pub use addons::retry::{Retry, RetryEvent};
 pub use local_command::LocalCommand;
 pub use process::Process;
 
@@ -69,6 +69,7 @@ impl Plugin for BevyLocalCommandsPlugin {
         app.add_event::<ProcessOutput>()
             .add_event::<ProcessCompleted>()
             .add_event::<ProcessError>()
+            .add_event::<RetryEvent>()
             .add_systems(
                 Update,
                 (


### PR DESCRIPTION
This change addresses #20 

Current limitations:
- Only supports static number of retries to be performed immediately upon failures
- ~Does not play well with the Cleanup addon~